### PR TITLE
Ensure lib bootstrap reads config before NF_BASE_URL guard

### DIFF
--- a/lib/index.php
+++ b/lib/index.php
@@ -6,8 +6,9 @@
 require_once __DIR__ . '/NF/UrlHelpers.php';
 require_once __DIR__ . '/NF/Database/ConnectionFactory.php';
 
+$config = $GLOBALS['nf_app_config'] ?? null;
+
 if (!defined('NF_BASE_URL')) {
-    $config = $GLOBALS['nf_app_config'] ?? null;
     $server = $_SERVER ?? [];
 
     if (!is_array($server)) {


### PR DESCRIPTION
## Summary
- pull `$nf_app_config` into a local variable before guarding NF_BASE_URL so the database bootstrap always receives configuration

## Testing
- composer validate
- find . -name '*.php' -print0 | xargs -0 -n1 php -l
- php tools/detect_duplicates.php
- php tools/php_lint_audit.php

------
https://chatgpt.com/codex/tasks/task_e_68cdbed86e60832eb9711f92a25f179c