### PR TITLE
Modernize caching keys and host utilities

### DIFF
--- a/lib/NF/Url/HostUtils.php
+++ b/lib/NF/Url/HostUtils.php
@@ -49,10 +49,6 @@ if (!function_exists('nf_extract_host_and_port')) {
     }
 }
 
-if (!function_exists('nf_sanitize_detected_host')) {
-    function nf_sanitize_detected_host(string $host): string
-    {
-        $host = strtolower(trim($host));
 if (!function_exists('nf_normalize_idn_host')) {
     /**
      * Converts internationalised domain names into their ASCII representation

--- a/lib/XG_Form.php
+++ b/lib/XG_Form.php
@@ -178,8 +178,9 @@ class XG_Form {
      *  @return     string
      */
     public function hidden($name) {
-        // TODO: Use xnhtmlentities instead of xg_xmlentities, which is intended for xml contexts [Jon Aquino 2008-04-02]
-        return '<input type="hidden" name="'.$name.'" value="'.xg_xmlentities($this->_values[$name]).'" />';
+        $value = $this->_values[$name] ?? '';
+
+        return '<input type="hidden" name="'.$name.'" value="'.xnhtmlentities((string) $value).'" />';
     }
 
     /**

--- a/lib/index.php
+++ b/lib/index.php
@@ -6,8 +6,6 @@
 require_once __DIR__ . '/NF/UrlHelpers.php';
 require_once __DIR__ . '/NF/Database/ConnectionFactory.php';
 
-if (!defined('NF_BASE_URL')) {
-    $config = $GLOBALS['nf_app_config'] ?? null;
 $config = $GLOBALS['nf_app_config'] ?? null;
 
 if (!defined('NF_BASE_URL')) {

--- a/tests/integration/url_host_utils_test.php
+++ b/tests/integration/url_host_utils_test.php
@@ -28,9 +28,6 @@ function testSlugDerivation(): void
     assertSame('custom-value', nf_derive_slug_from_host('custom_value.example.com', 'example.com'), 'Invalid characters should be normalised to hyphens');
 }
 
-$tests = [
-    'Base domain derivation' => 'testBaseDomainDerivation',
-    'Slug derivation' => 'testSlugDerivation',
 function testIdnHostNormalisation(): void
 {
     $idnHost = 'münich.example';

--- a/widgets/index/controllers/FeatureController.php
+++ b/widgets/index/controllers/FeatureController.php
@@ -90,9 +90,17 @@ class Index_FeatureController extends W_Controller {
            $this->backLink = XG_App::getPreviousStepUrl();
            $this->nextLink = XG_App::getNextStepUrl();
        }
-       // TODO: Instead of (count(array_keys(XN_Application::load()->premiumServices)) < 1), we can probably just check !XN_Application::load()->premiumServices [Jon Aquino 2008-09-15]
-       $this->showPremiumServicesPromo = (count(array_keys(XN_Application::load()->premiumServices)) < 1) && XG_SecurityHelper::userIsOwner() && XG_App::appIsLaunched();
-       $this->premiumServicesUrl = 'http://' . XN_AtomHelper::HOST_APP('www') . '/home/apps/premium?appUrl=' . XN_Application::load()->relativeUrl;
+       $application = XN_Application::load();
+       $premiumServices = $application->premiumServices;
+       $hasPremiumServices = false;
+       if (is_array($premiumServices) || $premiumServices instanceof Countable) {
+           $hasPremiumServices = count($premiumServices) > 0;
+       } else {
+           $hasPremiumServices = (bool) $premiumServices;
+       }
+
+       $this->showPremiumServicesPromo = (!$hasPremiumServices) && XG_SecurityHelper::userIsOwner() && XG_App::appIsLaunched();
+       $this->premiumServicesUrl = 'http://' . XN_AtomHelper::HOST_APP('www') . '/home/apps/premium?appUrl=' . $application->relativeUrl;
        $this->initialVisibleSourceFeatureCount = XG_App::appIsLaunched() ? 9999 : 6;
    }
 

--- a/widgets/index/controllers/IndexController.php
+++ b/widgets/index/controllers/IndexController.php
@@ -5,6 +5,7 @@ XG_App::includeFileOnce('/lib/XG_ModuleHelper.php');
 XG_App::includeFileOnce('/lib/XG_Message.php');
 XG_App::includeFileOnce('/lib/XG_MetatagHelper.php');
 XG_App::includeFileOnce('/lib/XG_FullNameHelper.php');
+XG_App::includeFileOnce('/lib/XG_HttpHelper.php');
 
 class Index_IndexController extends XG_BrowserAwareController {
 
@@ -25,8 +26,8 @@ class Index_IndexController extends XG_BrowserAwareController {
     public function action_index() {
         /** Cache approach index-signedout */
         if (! ($this->_user->isLoggedIn() || XG_App::getLogoutCookie())) {
-            $this->setCaching(array(crc32($_SERVER['QUERY_STRING'])), 300);
-            // TODO: Better to use md5(XG_HttpHelper::currentUrl())  [Jon Aquino 2007-10-25]
+            $cacheKey = md5(XG_HttpHelper::currentUrl());
+            $this->setCaching(array($cacheKey), 300);
         }
 
         $this->app = XN_Application::load();
@@ -53,8 +54,8 @@ class Index_IndexController extends XG_BrowserAwareController {
     public function action_index_iphone() {
         /** Cache approach index-signedout */
         if (! ($this->_user->isLoggedIn() || XG_App::getLogoutCookie())) {
-            $this->setCaching(array(crc32($_SERVER['QUERY_STRING'])), 300);
-            // TODO: Better to use md5(XG_HttpHelper::currentUrl())  [Jon Aquino 2007-10-25]
+            $cacheKey = md5(XG_HttpHelper::currentUrl());
+            $this->setCaching(array($cacheKey), 300);
         }
         $this->enabledModules = XG_ModuleHelper::getEnabledModules();
         $this->navEntries = XG_IPhoneHelper::getNavEntries();

--- a/widgets/photo/controllers/AlbumController.php
+++ b/widgets/photo/controllers/AlbumController.php
@@ -248,12 +248,10 @@ class Photo_AlbumController extends W_Controller {
     }
 
     private function handleSortingAndPagination($filters, $sort) {
+        XG_App::includeFileOnce('/lib/XG_PaginationHelper.php');
         $this->pageSize = 20;
-        // TODO: Use XG_PaginationHelper::computeStart(). [Jon Aquino 2008-02-16]
-        $this->begin = 0;
-        if (intval($_GET['page']) > 0) {
-            $this->begin = ($_GET['page'] - 1) * $this->pageSize;
-        }
+        $page = $_GET['page'] ?? null;
+        $this->begin = XG_PaginationHelper::computeStart($page, $this->pageSize);
         $albumData = Photo_AlbumHelper::getSortedAlbums($filters, $sort, $this->begin, $this->begin + $this->pageSize);
         $this->albums = $albumData['albums'];
         $this->numAlbums = $albumData['numAlbums'];
@@ -307,8 +305,7 @@ class Photo_AlbumController extends W_Controller {
         $this->showFacebookMeta = array_key_exists('from', $_GET) && ($_GET['from'] === 'fb');
         if($_GET['rss']=='yes'){
             $appname = XN_Application::load()->name;
-            // TODO: Use xg_xmlentities instead of htmlspecialchars [Jon Aquino 2008-02-20]
-            $this->title = htmlspecialchars($this->album->title, ENT_COMPAT, 'UTF-8');
+            $this->title = xg_xmlentities($this->album->title);
             $this->description = xg_xmlentities(xg_text('ALBUM_BY_X_ON_X', $this->album->contributorName, $appname));
             $this->link = $this->_buildUrl('album','show', '?id=' . $this->album->id);
             if ($this->my->coverPhotoId) {

--- a/widgets/video/controllers/VideoController.php
+++ b/widgets/video/controllers/VideoController.php
@@ -532,8 +532,8 @@ class Video_VideoController extends W_Controller {
             //  Users not logged in can see a cached page
             //  Detail page - cache only if we're caching order n items (BAZ-2969)
             if (XG_Cache::cacheOrderN()) {
-                $this->setCaching(array(crc32($_SERVER['QUERY_STRING'])), 300);
-                // TODO: Better to use md5(XG_HttpHelper::currentUrl())  [Jon Aquino 2007-10-25]
+                $cacheKey = md5(XG_HttpHelper::currentUrl());
+                $this->setCaching(array($cacheKey), 300);
             }
         }
         if ($this->error = Video_SecurityHelper::checkVisibleToCurrentUser($this->_user, $this->video)) {


### PR DESCRIPTION
## Summary
- switch form hidden input encoding to use `xnhtmlentities` with a null-safe default
- reuse `XN_Application` data when deciding whether to show premium-service promos
- adopt md5 hashes of `XG_HttpHelper::currentUrl()` for cache keys on index and video detail actions
- reuse `XG_PaginationHelper::computeStart()` in the photo album controller and escape RSS titles via `xg_xmlentities`
- tidy the bootstrap to avoid duplicate NF base URL initialisation and fix malformed host utility/test definitions

## Testing
- composer validate
- find . -name '*.php' -print0 | xargs -0 -n1 -P8 php -l
- php tools/detect_duplicates.php
- php tools/php_lint_audit.php

------
https://chatgpt.com/codex/tasks/task_e_68cde37658e8832ea5d0bfd92064b7f5